### PR TITLE
Fix picking events when multiple tools are connected to the same axes

### DIFF
--- a/src/mpltoolbox/patch.py
+++ b/src/mpltoolbox/patch.py
@@ -40,6 +40,9 @@ class Patch:
     def __str__(self):
         return repr(self)
 
+    def __eq__(self, other):
+        return self.id == other.id
+
     def _update_vertices(self):
         self._vertices.set_data(*self._make_vertices())
 

--- a/src/mpltoolbox/tool.py
+++ b/src/mpltoolbox/tool.py
@@ -244,9 +244,11 @@ class Tool:
             self.call_on_create(child)
 
     def _on_pick(self, event: Event):
-        mev = event.mouseevent
         if self._get_active_tool():
             return
+        if event.artist.parent not in self.children:
+            return
+        mev = event.mouseevent
         if mev.inaxes != self._ax:
             return
         art = event.artist


### PR DESCRIPTION
When you would connect 2 tools to the same axes: e.g. rectangles and vspans
```Py
%matplotlib widget
import matplotlib.pyplot as plt
import mpltoolbox as tbx

fig, ax = plt.subplots(dpi=96)
ax.set_xlim(0, 100)
ax.set_ylim(0, 100)

rects = tbx.Rectangles(ax=ax, autostart=False)
vspans = tbx.Vspans(ax=ax, autostart=False)
```

- start rectangle tool (`rects.start()`)
- make a rectangle
- stop rectangle tool (`rects.stop()`)
- start vspans tool (`vspans.start()`)
- make a vspan
- click one of the vectices of the rectangle
- rectangle should not resize because tool is supposed to be inactive.

To fix this, we do not handle picking events coming from an artist not part of your own children.