### PR TITLE
Remove copyright year

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+# Copyright (c) Scipp contributors (https://github.com/scipp)
 
 import os
 import sys

--- a/src/mpltoolbox/__init__.py
+++ b/src/mpltoolbox/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+# Copyright (c) Scipp contributors (https://github.com/scipp)
 
 # flake8: noqa
 

--- a/src/mpltoolbox/ellipses.py
+++ b/src/mpltoolbox/ellipses.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+# Copyright (c) Scipp contributors (https://github.com/scipp)
 
 from .patch import Patch
 from .tool import Tool

--- a/src/mpltoolbox/event.py
+++ b/src/mpltoolbox/event.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+# Copyright (c) Scipp contributors (https://github.com/scipp)
 
 from dataclasses import dataclass
 from typing import List, Optional

--- a/src/mpltoolbox/hspans.py
+++ b/src/mpltoolbox/hspans.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+# Copyright (c) Scipp contributors (https://github.com/scipp)
 
 from .patch import Patch
 from .tool import Tool

--- a/src/mpltoolbox/lines.py
+++ b/src/mpltoolbox/lines.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+# Copyright (c) Scipp contributors (https://github.com/scipp)
 
 from .tool import Tool
 from .utils import parse_kwargs

--- a/src/mpltoolbox/patch.py
+++ b/src/mpltoolbox/patch.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+# Copyright (c) Scipp contributors (https://github.com/scipp)
 
 from .utils import parse_kwargs
 from matplotlib.pyplot import Axes, Artist

--- a/src/mpltoolbox/points.py
+++ b/src/mpltoolbox/points.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+# Copyright (c) Scipp contributors (https://github.com/scipp)
 
 from .lines import Line
 from .tool import Tool

--- a/src/mpltoolbox/polygons.py
+++ b/src/mpltoolbox/polygons.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+# Copyright (c) Scipp contributors (https://github.com/scipp)
 
 from .tool import Tool
 from .utils import parse_kwargs

--- a/src/mpltoolbox/rectangles.py
+++ b/src/mpltoolbox/rectangles.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+# Copyright (c) Scipp contributors (https://github.com/scipp)
 
 from .patch import Patch
 from .tool import Tool

--- a/src/mpltoolbox/tool.py
+++ b/src/mpltoolbox/tool.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+# Copyright (c) Scipp contributors (https://github.com/scipp)
 
 from .event import DummyEvent
 from functools import partial

--- a/src/mpltoolbox/vspans.py
+++ b/src/mpltoolbox/vspans.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+# Copyright (c) Scipp contributors (https://github.com/scipp)
 
 from .patch import Patch
 from .tool import Tool

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+# Copyright (c) Scipp contributors (https://github.com/scipp)
 
 import matplotlib
 import matplotlib.pyplot as plt

--- a/tests/lines_test.py
+++ b/tests/lines_test.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+# Copyright (c) Scipp contributors (https://github.com/scipp)
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/points_test.py
+++ b/tests/points_test.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+# Copyright (c) Scipp contributors (https://github.com/scipp)
 
 import matplotlib.pyplot as plt
 


### PR DESCRIPTION
See for example https://nexb.com/do-you-really-need-to-update-the-copyright-each-new-year/#:~:text=The%20Linux%20Foundation%20recommends%20as,was%20licensed%20for%20distribution%20as
or
https://opensource.stackexchange.com/questions/6389/how-do-the-years-specified-in-a-copyright-statement-work
for posts which state that copyright year is not really needed.