### PR TITLE
Allow to drag vertices after tool was stopped

### DIFF
--- a/src/mpltoolbox/tool.py
+++ b/src/mpltoolbox/tool.py
@@ -165,6 +165,8 @@ class Tool:
             self._connections["pick_event"] = self._fig.canvas.mpl_connect(
                 "pick_event", self._on_pick
             )
+        for child in self.children:
+            child._vertices.set_visible(True)
 
     def stop(self):
         """
@@ -181,6 +183,8 @@ class Tool:
         existing children cannot be moved or resized.
         """
         self._disconnect(list(self._connections.keys()))
+        for child in self.children:
+            child._vertices.set_visible(False)
 
     def clear(self):
         """

--- a/src/mpltoolbox/tool.py
+++ b/src/mpltoolbox/tool.py
@@ -168,22 +168,36 @@ class Tool:
 
     def stop(self):
         """
-        Dectivate the tool.
+        Dectivate adding new children, but resizing and moving existing children is
+        still possible.
         """
         self._disconnect(
             [key for key in self._connections.keys() if key != "pick_event"]
         )
+
+    def freeze(self):
+        """
+        Deactivate the tool but keep the children. No new children can be added and
+        existing children cannot be moved or resized.
+        """
+        self._disconnect(list(self._connections.keys()))
+
+    def clear(self):
+        """
+        Remove all children from the axes.
+        """
+        for a in self.children:
+            a.remove()
+        self.children.clear()
+        self._draw()
 
     def shutdown(self):
         """
         Deactivate the tool and remove all children from the axes.
         """
         self.stop()
-        for a in self.children:
-            a.remove()
-        self.children.clear()
         self._connections.clear()
-        self._draw()
+        self.clear()
 
     def _get_active_tool(self) -> str:
         return self._fig.canvas.toolbar.mode
@@ -333,7 +347,7 @@ class Tool:
     def _release_owner(self, event: Event, kind: str):
         self._disconnect(["motion_notify_event", "button_release_event"])
         self._pick_lock = False
-        self._ax._mpltoolbox_lock = True
+        self._ax._mpltoolbox_lock = False
         if (kind == "vertex") and (self.on_vertex_release is not None):
             self.call_on_vertex_release(self._moving_vertex_owner)
         elif (kind == "drag") and (self.on_drag_release is not None):

--- a/src/mpltoolbox/tool.py
+++ b/src/mpltoolbox/tool.py
@@ -161,15 +161,18 @@ class Tool:
         self._connections["button_press_event"] = self._fig.canvas.mpl_connect(
             "button_press_event", self._on_button_press
         )
-        self._connections["pick_event"] = self._fig.canvas.mpl_connect(
-            "pick_event", self._on_pick
-        )
+        if "pick_event" not in self._connections:
+            self._connections["pick_event"] = self._fig.canvas.mpl_connect(
+                "pick_event", self._on_pick
+            )
 
     def stop(self):
         """
         Dectivate the tool.
         """
-        self._disconnect(list(self._connections.keys()))
+        self._disconnect(
+            [key for key in self._connections.keys() if key != "pick_event"]
+        )
 
     def shutdown(self):
         """
@@ -184,6 +187,9 @@ class Tool:
 
     def _get_active_tool(self) -> str:
         return self._fig.canvas.toolbar.mode
+
+    def _locked_by_other_tool(self) -> bool:
+        return getattr(self._ax, "_mpltoolbox_lock", False)
 
     def _disconnect(self, keys: List[str]):
         for key in keys:
@@ -200,10 +206,10 @@ class Tool:
             event.button != 1
             or self._pick_lock
             or self._get_active_tool()
+            or self._locked_by_other_tool()
             or event.modifiers
+            or event.inaxes != self._ax
         ):
-            return
-        if event.inaxes != self._ax:
             return
         if "motion_notify_event" not in self._connections:
             self._nclicks = 0
@@ -244,18 +250,19 @@ class Tool:
             self.call_on_create(child)
 
     def _on_pick(self, event: Event):
-        if self._get_active_tool():
-            return
-        if event.artist.parent not in self.children:
-            return
         mev = event.mouseevent
-        if mev.inaxes != self._ax:
+        if (
+            self._get_active_tool()
+            or event.artist.parent not in self.children
+            or mev.inaxes != self._ax
+        ):
             return
         art = event.artist
         if (mev.button == 1) and ("ctrl" not in mev.modifiers):
             if not art.parent.is_moveable(art):
                 return
             self._pick_lock = True
+            self._ax._mpltoolbox_lock = True
             self._grab_vertex(event)
         if mev.button == 3:
             if not art.parent.is_draggable(art):
@@ -326,6 +333,7 @@ class Tool:
     def _release_owner(self, event: Event, kind: str):
         self._disconnect(["motion_notify_event", "button_release_event"])
         self._pick_lock = False
+        self._ax._mpltoolbox_lock = True
         if (kind == "vertex") and (self.on_vertex_release is not None):
             self.call_on_vertex_release(self._moving_vertex_owner)
         elif (kind == "drag") and (self.on_drag_release is not None):


### PR DESCRIPTION
This PR brings a more intuitive behaviour of being able to still drag and resize patches after a tool has been stopped.
This is useful in the case where multiple tools are being used on the same axes.
Example:
```Py
import matplotlib.pyplot as plt
import mpltoolbox as tbx
%matplotlib widget

fig, ax = plt.subplots()
ax.set_xlim(0, 100)
ax.set_ylim(0, 100)

rectangles = tbx.Rectangles(ax=ax, autostart=False)
ellipses = tbx.Ellipses(ax=ax, autostart=False)
```
which opens the figure.
Then
```Py
rectangles.start()
```
Draw a rectangle, then
```Py
rectangles.stop()
ellipses.start()
```
Draw an ellipse, and then one would expect to still be able to resize/move the rectangles.

In this PR, we also add a `tool.freeze()` method, which is like the old `stop()`, and a `clear()` method which removes all children from the figure.