### PR TITLE
Add kwargs to control behaviour of dragging artists and vertices

### DIFF
--- a/src/mpltoolbox/ellipses.py
+++ b/src/mpltoolbox/ellipses.py
@@ -42,7 +42,7 @@ class Ellipse(Patch):
             np.array([btm, btm, btm, mid, top, top, top, mid]),
         )
 
-    def move_vertex(self, event: Event, ind: int):
+    def move_vertex(self, event: Event, ind: int, **ignored):
         props = super().get_new_patch_props(event=event, ind=ind)
         center = list(self.center)
         if "width" in props:

--- a/src/mpltoolbox/hspans.py
+++ b/src/mpltoolbox/hspans.py
@@ -37,7 +37,7 @@ class Hspan(Patch):
     def _make_vertices(self) -> tuple[tuple[float, float], tuple[float, float]]:
         return ([0.5, 0.5], [self.bottom, self.top])
 
-    def move_vertex(self, event: Event, ind: int):
+    def move_vertex(self, event: Event, ind: int, **ignored):
         y = event.ydata
         if ind == 0:
             self.bottom = y

--- a/src/mpltoolbox/lines.py
+++ b/src/mpltoolbox/lines.py
@@ -46,12 +46,16 @@ class Line:
     def __len__(self):
         return len(self.x)
 
-    def move_vertex(self, event: Event, ind: int):
+    def move_vertex(
+        self, event: Event, ind: int, move_x: bool = True, move_y: bool = True
+    ):
         new_data = self.xy
         if ind is None:
             ind = -1
-        new_data[0][ind] = event.xdata
-        new_data[1][ind] = event.ydata
+        if move_x:
+            new_data[0][ind] = event.xdata
+        if move_y:
+            new_data[1][ind] = event.ydata
         self.xy = new_data
 
     def after_persist_vertex(self, event: Event):

--- a/src/mpltoolbox/points.py
+++ b/src/mpltoolbox/points.py
@@ -49,9 +49,13 @@ class Point(Line):
     def xy(self, xy: float):
         self._line.set_data([xy[0]], [xy[1]])
 
-    def move_vertex(self, event: Event, ind: int):
-        self.x = event.xdata
-        self.y = event.ydata
+    def move_vertex(
+        self, event: Event, ind: int, move_x: bool = True, move_y: bool = True
+    ):
+        if move_x:
+            self.x = event.xdata
+        if move_y:
+            self.y = event.ydata
 
     def after_persist_vertex(self, event: Event):
         return

--- a/src/mpltoolbox/polygons.py
+++ b/src/mpltoolbox/polygons.py
@@ -85,7 +85,9 @@ class Polygon:
         )
         return dist
 
-    def move_vertex(self, event: Event, ind: int):
+    def move_vertex(
+        self, event: Event, ind: int, move_x: bool = True, move_y: bool = True
+    ):
         x = event.xdata
         y = event.ydata
         if self._get_distance_from_first_point(x, y) < self._distance_from_first_point:
@@ -99,8 +101,10 @@ class Polygon:
             ind = -1
         elif ind in (0, len(new_data[0])):
             ind = [0, -1]
-        new_data[0][ind] = x
-        new_data[1][ind] = y
+        if move_x:
+            new_data[0][ind] = x
+        if move_y:
+            new_data[1][ind] = y
         self.xy = new_data
         self._update_fill()
 

--- a/src/mpltoolbox/rectangles.py
+++ b/src/mpltoolbox/rectangles.py
@@ -42,7 +42,7 @@ class Rectangle(Patch):
         y[1::2] = y_mid
         return (x, y)
 
-    def move_vertex(self, event: Event, ind: int):
+    def move_vertex(self, event: Event, ind: int, **ignored):
         props = super().get_new_patch_props(event=event, ind=ind)
         props["xy"] = props.pop("corner")
         self.update(**props)

--- a/src/mpltoolbox/tool.py
+++ b/src/mpltoolbox/tool.py
@@ -11,6 +11,27 @@ from .event import DummyEvent
 
 
 class Tool:
+    """
+    A tool for creating and manipulating artists on a matplotlib figure.
+    This is the base class for all tools in mpltoolbox.
+
+    :param ax: The axes to which the tool is attached.
+    :param spawner: An object constructor that creates the artists.
+    :param autostart: If `True`, the tool is activated immediately.
+    :param on_create: A function to be called when a new artist is created.
+    :param on_remove: A function to be called when an artist is removed.
+    :param on_change: A function to be called when an artist is changed.
+    :param on_vertex_press: A function to be called when a vertex is pressed.
+    :param on_vertex_move: A function to be called when a vertex is moved.
+    :param on_vertex_release: A function to be called when a vertex is released.
+    :param on_drag_press: A function to be called when an artist is dragged.
+    :param on_drag_move: A function to be called when an artist is moved.
+    :param on_drag_release: A function to be called when an artist is released.
+    :param enable_drag: If `True`, dragging the artists is enabled.
+    :param enable_remove: If `True`, removing the artists is enabled.
+    :param kwargs: Additional keyword arguments for the artist constructor.
+    """
+
     def __init__(
         self,
         ax: Axes,
@@ -26,11 +47,16 @@ class Tool:
         on_drag_press: Callable | None = None,
         on_drag_move: Callable | None = None,
         on_drag_release: Callable | None = None,
+        enable_drag: bool = True,
+        enable_remove: bool = True,
         **kwargs,
     ):
         self._ax = ax
         self._fig = ax.get_figure()
         self._connections = {}
+
+        self._enable_drag = enable_drag
+        self._enable_remove = enable_remove
 
         self._on_create = []
         self._on_remove = []
@@ -285,12 +311,12 @@ class Tool:
             self._ax._mpltoolbox_lock = True
             self._grab_vertex(event)
         if mev.button == 3:
-            if not art.parent.is_draggable(art):
+            if (not art.parent.is_draggable(art)) or (not self._enable_drag):
                 return
             self._pick_lock = True
             self._grab_owner(event)
         if (mev.button == 2) or ((mev.button == 1) and ("ctrl" in mev.modifiers)):
-            if not art.parent.is_removable(art):
+            if (not art.parent.is_removable(art)) or (not self._enable_remove):
                 return
             self._remove_owner(art.parent)
 

--- a/src/mpltoolbox/tool.py
+++ b/src/mpltoolbox/tool.py
@@ -3,6 +3,7 @@
 
 from collections.abc import Callable
 from functools import partial
+from typing import Any
 
 from matplotlib.backend_bases import Event
 from matplotlib.pyplot import Axes
@@ -28,7 +29,12 @@ class Tool:
     :param on_drag_move: A function to be called when an artist is moved.
     :param on_drag_release: A function to be called when an artist is released.
     :param enable_drag: If `True`, dragging the artists is enabled.
+        If `'xonly'` or `'yonly'`, dragging is restricted to the x or y direction,
+        respectively. If `False`, dragging is disabled.
     :param enable_remove: If `True`, removing the artists is enabled.
+    :param enable_vertex_move: If `True`, moving the vertices of the artists is
+        enabled. If `'xonly'` or `'yonly'`, moving is restricted to the x or y
+        direction, respectively. If `False`, moving vertices is disabled.
     :param kwargs: Additional keyword arguments for the artist constructor.
     """
 
@@ -47,8 +53,9 @@ class Tool:
         on_drag_press: Callable | None = None,
         on_drag_move: Callable | None = None,
         on_drag_release: Callable | None = None,
-        enable_drag: bool = True,
-        enable_remove: bool = True,
+        enable_drag: bool | str = True,
+        enable_remove: bool | str = True,
+        enable_vertex_move: bool | str = True,
         **kwargs,
     ):
         self._ax = ax
@@ -57,6 +64,7 @@ class Tool:
 
         self._enable_drag = enable_drag
         self._enable_remove = enable_remove
+        self._enable_vertex_move = enable_vertex_move
 
         self._on_create = []
         self._on_remove = []
@@ -275,10 +283,17 @@ class Tool:
     def _on_motion_notify(self, event: Event):
         self._move_vertex(event=event, ind=None, owner=self.children[-1])
 
-    def _move_vertex(self, event: Event, ind: int, owner):
+    def _move_vertex(
+        self,
+        event: Event,
+        ind: int,
+        owner: Any,
+        move_x: bool = True,
+        move_y: bool = True,
+    ):
         if event.inaxes != self._ax:
             return
-        owner.move_vertex(event=event, ind=ind)
+        owner.move_vertex(event=event, ind=ind, move_x=move_x, move_y=move_y)
         self._draw()
 
     def _persist_vertex(self, event: Event, owner):
@@ -305,7 +320,7 @@ class Tool:
             return
         art = event.artist
         if (mev.button == 1) and ("ctrl" not in mev.modifiers):
-            if not art.parent.is_moveable(art):
+            if (not art.parent.is_moveable(art)) or (not self._enable_vertex_move):
                 return
             self._pick_lock = True
             self._ax._mpltoolbox_lock = True
@@ -340,8 +355,16 @@ class Tool:
             self.call_on_vertex_press(self._moving_vertex_owner)
 
     def _on_vertex_motion(self, event: Event):
+        # We only lock vertex movement here because we do not want to restrict x/y
+        # motion while the artist is being created, only when moving an existing vertex.
+        move_x = self._enable_vertex_move in (True, "xonly")
+        move_y = self._enable_vertex_move in (True, "yonly")
         self._move_vertex(
-            event=event, ind=self._moving_vertex_index, owner=self._moving_vertex_owner
+            event=event,
+            ind=self._moving_vertex_index,
+            owner=self._moving_vertex_owner,
+            move_x=move_x,
+            move_y=move_y,
         )
         if self.on_vertex_move is not None:
             self.call_on_vertex_move(self._moving_vertex_owner)
@@ -364,8 +387,10 @@ class Tool:
     def _move_owner(self, event: Event):
         if event.inaxes != self._ax:
             return
-        dx = event.xdata - self._grab_mouse_origin[0]
-        dy = event.ydata - self._grab_mouse_origin[1]
+        move_x = self._enable_drag in (True, "xonly")
+        move_y = self._enable_drag in (True, "yonly")
+        dx = (event.xdata - self._grab_mouse_origin[0]) if move_x else 0
+        dy = (event.ydata - self._grab_mouse_origin[1]) if move_y else 0
         self._grabbed_owner.xy = (
             self._grabbed_owner_origin[0] + dx,
             self._grabbed_owner_origin[1] + dy,

--- a/src/mpltoolbox/vspans.py
+++ b/src/mpltoolbox/vspans.py
@@ -43,7 +43,7 @@ class Vspan(Patch):
     def _make_vertices(self) -> tuple[tuple[float, float], tuple[float, float]]:
         return ([self.left, self.right], [0.5, 0.5])
 
-    def move_vertex(self, event: Event, ind: int):
+    def move_vertex(self, event: Event, ind: int, **ignored):
         x = event.xdata
         if ind == 0:
             self.left = x


### PR DESCRIPTION
This PR adds the following kwargs to all tools:

- `enable_drag`: If `True`, dragging the artists is enabled. If `'xonly'` or `'yonly'`, dragging is restricted to the x or y direction, respectively. If `False`, dragging is disabled.
- `enable_remove`: If `True`, removing the artists is enabled.
- `enable_vertex_move`: If `True`, moving the vertices of the artists is enabled. If `'xonly'` or `'yonly'`, moving is restricted to the x or y direction, respectively. If `False`, moving vertices is disabled.

Note that some of these options don't make sense for all artists (e.g. Vspans, Hspans...).

@g5t